### PR TITLE
Updates for migration to donate-static 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lego"]
 	path = lego
-	url = https://git.torproject.org/project/web/lego.git
+	url = ssh://git@git.giantrabbit.com/tor/lego.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lego"]
 	path = lego
-	url = ssh://git@git.giantrabbit.com/tor/lego.git
+	url = https://git.torproject.org/project/web/lego.git

--- a/content/civicrm-mailing-error/contents.lr
+++ b/content/civicrm-mailing-error/contents.lr
@@ -1,0 +1,5 @@
+_model: page
+---
+title: Error
+---
+_template: page-no-sidebar.html

--- a/content/subscription-confirmed/contents.lr
+++ b/content/subscription-confirmed/contents.lr
@@ -1,0 +1,15 @@
+_model: page
+---
+title: Subscription Confirmed
+---
+html: errors.html
+---
+_template: page-no-sidebar.html
+---
+body:
+
+Thanks for joining our email list - you'll hear from us soon! In the meantime, follow @TorProject on Twitter to keep in touch.
+
+As a non-profit organization, we rely on contributions from people like you to help us create and maintain technology used by millions of users daily to browse, communicate, and express themselves online privately. Every little bit helps - please donate today.
+
+<a class="btn btn-purple" href="https://www.torproject.org/donate">Donate Now</a>

--- a/content/subscription-error/contents.lr
+++ b/content/subscription-error/contents.lr
@@ -4,4 +4,4 @@ title: Error Confirming Your Subscription
 ---
 html: errors.html
 ---
-_template: errors.html
+_template: page-no-sidebar.html

--- a/content/subscription-error/contents.lr
+++ b/content/subscription-error/contents.lr
@@ -1,0 +1,7 @@
+_model: page
+---
+title: Error Confirming Your Subscription
+---
+html: errors.html
+---
+_template: errors.html

--- a/content/subscription-request-sent/contents.lr
+++ b/content/subscription-request-sent/contents.lr
@@ -1,0 +1,11 @@
+_model: page
+---
+title: Confirmation Sent
+---
+html: errors.html
+---
+_template: page-no-sidebar.html
+---
+body:
+
+ A request for confirmation has been sent to your email address. Once you click on that link, you will be subscribed. 

--- a/templates/errors.html
+++ b/templates/errors.html
@@ -1,0 +1,28 @@
+{% from "macros/archive.html" import render_intro_post %}
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="{{ '/static/css/bootstrap.css'|asseturl }}">
+<link rel="stylesheet" href="{{ '/static/fonts/fontawesome/css/all.min.css'|asseturl }}" rel="stylesheet">
+<title>{% block title %}{{ this.title }}{% endblock %}</title>
+<body class="no-gutters" data-spy="scroll" data-target="#sidenav-topics" id="topics" data-children=".item">
+  <header>
+    {% include 'navbar.html' %}
+  </header>
+  <div class="page bg-light">
+    <div class="container-fluid">
+      <div class="row flex-xl-nowrap">
+        <main role="main" class="col-sm-12 col-xs-12 ml-sm-auto col-md-9 col-lg-9 mx-auto m-5">
+          <h2>{{ this.title }}</h2>
+          <div class="errors">
+          </div>
+          {% block body %}{% endblock %}
+          <script src="{{ '/static/js/errors.js'|asseturl }}" ></script>
+        </main>
+      </div>
+    </div>
+  </div>
+  <footer class="footer">
+    {% include 'footer.html' %}
+  </footer>
+</body>

--- a/templates/intro.html
+++ b/templates/intro.html
@@ -30,7 +30,7 @@
 <div class="row mb-1">
   <div class="col-12">
     <div class="row mt-4 mb-2">
-      <form action="https://donate.torproject.org/subscription-request" method="POST" class="form-wide">
+      <form action="https://donate-api.torproject.org/subscription-request" method="POST" class="form-wide">
         <input type="hidden" name="returnToReferrer" value="1" />
         <div class="form-group row">
           <div class="col-sm-12 errors">

--- a/templates/intro.html
+++ b/templates/intro.html
@@ -30,7 +30,7 @@
 <div class="row mb-1">
   <div class="col-12">
     <div class="row mt-4 mb-2">
-      <form action="https://tor-donate.local/subscription-request" method="POST" class="form-wide">
+      <form action="https://donate.torproject.org/subscription-request" method="POST" class="form-wide">
         <input type="hidden" name="returnToReferrer" value="1" />
         <div class="form-group row">
           <div class="col-sm-12 errors">

--- a/templates/intro.html
+++ b/templates/intro.html
@@ -30,16 +30,32 @@
 <div class="row mb-1">
   <div class="col-12">
     <div class="row mt-4 mb-2">
-      <form action="https://donate.torproject.org/subscription-request" method="POST" class="form-wide">
+      <form action="https://tor-donate.local/subscription-request" method="POST" class="form-wide">
+        <input type="hidden" name="returnToReferrer" value="1" />
         <div class="form-group row">
-          <div class="col-sm-10">
+          <div class="col-sm-12 errors">
+          </div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-12">
             <input class="form-control form-control-lg form-required" id="email"
                 name="email" placeholder="* Email Address" value="" type="email" />
           </div>
-          <input class="donate btn btn-lg btn-success btn-block col-2" value="Join" type="submit" />
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-6 captcha">
+            <input id="captcha" type="text" class="form-control form-control-lg form-required" data-name="captcha" data-stripe="captcha" aria-label="captcha" name="captcha" size="4" placeholder="* Enter the 4 letters (case insenstive) that appear below">
+            <img src="https://tor-donate.local/captcha" border="0" />
+          </div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-12">
+            <input class="donate btn btn-lg btn-success btn-block col-2" value="Join" type="submit" />
+          </div>
         </div>
       </form>
     </div>
   </div>
 </div>
+<script src="{{ '/static/js/errors.js'|asseturl }}" ></script>
 {% endblock %}

--- a/templates/newsletter.html
+++ b/templates/newsletter.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="{{ '/static/style.css'|asseturl }}">
+<script src="{{ '/static/js/errors.js'|asseturl }}"></script>
 
 <title>{% block title %}{{ this.title }}{% endblock %}</title>
 <body>

--- a/templates/page-no-sidebar.html
+++ b/templates/page-no-sidebar.html
@@ -16,7 +16,7 @@
           <h2>{{ this.title }}</h2>
           <div class="errors">
           </div>
-          {% block body %}{% endblock %}
+          {% block body %}{{ this.body }}{% endblock %}
           <script src="{{ '/static/js/errors.js'|asseturl }}" ></script>
         </main>
       </div>


### PR DESCRIPTION
We are going to move all of the display parts of the current donate.torproject.org site to lektor so that it can be managed like all of the other web properties. Some of the pages on the current donate.torproject.org site are involved in managing newsletter subscriptions. These changes are updates to the newsletter site to handle errors and confirmation pages during the subscription process.